### PR TITLE
fix for mingw-w64 build

### DIFF
--- a/src/base.cc
+++ b/src/base.cc
@@ -16,14 +16,14 @@ limitations under the License.
 #include "base.h"
 
 #include <string>
-#ifdef COMPILER_MSVC
+#ifdef _WIN32
 #include <sstream>
 #endif  // COMPILER_MSVC
 
 namespace chrome_lang_id {
 
 // TODO(abakalov): Pick the most efficient approach.
-#ifdef COMPILER_MSVC
+#ifdef _WIN32
 std::string Int64ToString(int64 input) {
   std::stringstream stream;
   stream << input;


### PR DESCRIPTION
The build currently fails on Windows with `mingw-w64` because `to_string()` is not defined. With this fix I can confirm that it works.