### PR TITLE
add makefile and configure script

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,66 @@
+# Jeroen Ooms 2017 / jeroen@berkeley.edu
+# You may override default options below using environment variables
+
+# Your protobuf options
+PROTOC ?= protoc
+PROTOBUF_INCLUDE ?= -I/usr/local/include
+PROTOBUF_LIBS ?= -L/usr/local/lib -lprotobuf
+
+# Compiler options
+CXX ?= g++
+CXXFLAGS ?= -std=c++11 -pedantic
+CPPFLAGS ?= $(PROTOBUF_INCLUDE)
+
+# Linker options
+LDLIBS = -L. -lcld3 $(PROTOBUF_LIBS)
+CC = $(CXX)
+
+# CLD3 library object files
+LIBCLD3 = base.o embedding_feature_extractor.o embedding_network.o feature_extractor.o \
+	feature_types.o fml_parser.o language_identifier_features.o lang_id_nn_params.o \
+	nnet_language_identifier.o registry.o relevant_script_feature.o sentence_features.o \
+	utils.o workspace.o task_context.o task_context_params.o unicodetext.o \
+	script_span/fixunicodevalue.o script_span/generated_entities.o \
+	script_span/generated_ulscript.o script_span/getonescriptspan.o script_span/offsetmap.o \
+	script_span/text_processing.o script_span/utf8statetable.o \
+	cld_3/protos/feature_extractor.pb.o cld_3/protos/sentence.pb.o cld_3/protos/task_spec.pb.o
+
+# Note: language_identifier_features_test doesn't compile for me
+TESTS = script_detector_test relevant_script_feature_test script_span/getonescriptspan_test \
+	language_identifier_main
+
+# Default 'make' command builds and runs tests
+all: check
+
+libcld3.a: $(LIBCLD3)
+	$(AR) rcs libcld3.a $(LIBCLD3)	
+
+$(LIBCLD3): cld_3/protos/feature_extractor.pb.h cld_3/protos/sentence.pb.h cld_3/protos/task_spec.pb.h
+
+$(TESTS): libcld3.a
+
+protodir:
+	mkdir -p cld_3/protos
+
+cld_3/protos/feature_extractor.pb.cc cld_3/protos/feature_extractor.pb.h: protodir
+	$(PROTOC) feature_extractor.proto --cpp_out=./cld_3/protos
+
+cld_3/protos/sentence.pb.cc cld_3/protos/sentence.pb.h: protodir
+	$(PROTOC) sentence.proto --cpp_out=./cld_3/protos
+
+cld_3/protos/task_spec.pb.cc cld_3/protos/task_spec.pb.h: protodir
+	$(PROTOC) task_spec.proto --cpp_out=./cld_3/protos
+
+check: $(TESTS)
+	@echo "RUNNING relevant_script_feature_test" && ./relevant_script_feature_test
+	@echo "RUNNING script_detector_test" && ./script_detector_test
+	@echo "RUNNING getonescriptspan_test" && ./script_span/getonescriptspan_test
+	#@echo "RUNNING language_identifier_features_test" && ./language_identifier_features_test
+	@echo "RUNNING getonescriptspan_test" && ./language_identifier_main
+	@echo "Great success!"
+
+clean:
+	rm -Rf ./cld_3/protos
+	rm -f $(TESTS) $(LIBCLD3) libcld3.a
+	rm -f language_identifier_main.o language_identifier_features_test.o relevant_script_feature_test.o \
+	  script_detector_test.o script_span/getonescriptspan_test.o

--- a/src/configure
+++ b/src/configure
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Jeroen Ooms 2017 / jeroen@berkeley.edu
+# Running this script is optional. Usually the default 'make' should work
+PKG_CONFIG_NAME="protobuf"
+
+# Look for 'protoc' compiler
+if [ $(command -v protoc) ]; then
+  PROTOC_VERSION=$(protoc --version)
+  echo "Using ${PROTOC_VERSION} from $(command -v protoc)"
+else
+  echo "Failed to find protoc"
+  echo "Please install the 'protobuf-compiler' package for your system."
+  exit 1
+fi
+
+# Test if pkg-config info is available
+pkg-config --exists ${PKG_CONFIG_NAME}
+if [ $? -eq 0 ]; then
+	CFLAGS=$(pkg-config --cflags ${PKG_CONFIG_NAME})
+	LIBS=$(pkg-config --libs ${PKG_CONFIG_NAME})
+	MODVERSION=$(pkg-config --modversion ${PKG_CONFIG_NAME})
+	echo "Using CFLAGS=$CFLAGS"
+	echo "Using LIBS=$LIBS"
+	sed -i.bak "s#^PROTOBUF_INCLUDE.*#PROTOBUF_INCLUDE ?= ${CFLAGS}#" Makefile
+	sed -i.bak "s#^PROTOBUF_LIBS.*#PROTOBUF_LIBS ?= ${LIBS}#" Makefile	
+else
+	echo "Either 'pkg-config' or '${PKG_CONFIG_NAME}.pc' could not be found."
+	echo "Don't worry; the default 'make' flags probably work."
+	exit 0
+fi
+
+# Try to check if protoc version matches libproto
+if [[ $PROTOC_VERSION != *"$MODVERSION"* ]]; then
+  echo "Warning: protoc version $PROTOC_VERSION might not match libproto version $MODVERSION.";
+fi


### PR DESCRIPTION
As promised on the mailing list. This is the `make` config that I use for the R bindings. Hopefully this will help others to get started because it currently not obvious how to build cld3 standalone.

Basically the `makefile` should work out of the box. To build with 8 threads:

```
cd src
make -j8
```

This will first build the cld3 library, then build and link 4 test programs and then run them. If you only want to build the library you could do something like:

```
make libcld3.a
```

There is also an optional `configure` script that you can run to find `protoc` and `libprotobuf`. On most systems this should not be needed because the headers are in the standard include dir and `protoc` will be on the $PATH.

