### PR TITLE
small fix for BUILD.gn

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -88,8 +88,6 @@ static_library("cld_3") {
   ]
   public_deps = [
     "//third_party/protobuf:protobuf_lite",
-  ]
-  deps = [
     ":protos",
   ]
 }


### PR DESCRIPTION
generated pb.h is included from several header file in cld_3 target.
So generating action of pb.h needs to be in public_deps.

See below reference for more details.
https://gn.googlesource.com/gn/+/master/docs/reference.md#var_public_deps

This is for  https://crbug.com/931596