### PR TITLE
Fix CMakeList missing Protobuf_INCLUDE_DIRS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ add_definitions(-fPIC) # Position Independant Code
 add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
 add_definitions(-std=c++11) # Needed for std::to_string(), ...
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR}) # needed to include generated pb headers
+include_directories(${CMAKE_CURRENT_BINARY_DIR} ${Protobuf_INCLUDE_DIRS}) # needed to include generated pb headers
 
 add_library(${PROJECT_NAME} 
 	${PROTO_SRCS} ${PROTO_HDRS}


### PR DESCRIPTION
Just add Protobuf_INCLUDE_DIRS to include_directories() as needed if protobuf installed in custom location.