### PR TITLE
Add language list to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Compact Language Detector v3 (CLD3)
 
 * [Model](#model)
+* [Supported Languages](#supported-languages)
 * [Installation](#installation)
-* [Contact](#contact)
+* [Bugs and Feature Requests](#bugs-and-feature-requests)
 * [Credits](#credits)
 
 ### Model
@@ -25,6 +26,123 @@ To get a language prediction for the input text, we simply perform a forward
  pass through the network.
 
 ![Figure](model.png "CLD3")
+
+### Supported Languages
+
+The model outputs BCP-47-style language codes, shown in the table below. For
+some languages, output is differentiated by script. Language and script names
+from
+[Unicode CLDR](https://github.com/unicode-cldr/cldr-localenames-modern/blob/master/main/en).
+
+Output Code | Language Name   | Script Name
+----------- | --------------- | ------------------------------------------
+af          | Afrikaans       | Latin
+am          | Amharic         | Ethiopic
+ar          | Arabic          | Arabic
+bg          | Bulgarian       | Cyrillic
+bg-Latn     | Bulgarian       | Latin
+bn          | Bangla          | Bangla
+bs          | Bosnian         | Latin
+ca          | Catalan         | Latin
+ceb         | Cebuano         | Latin
+co          | Corsican        | Latin
+cs          | Czech           | Latin
+cy          | Welsh           | Latin
+da          | Danish          | Latin
+de          | German          | Latin
+el          | Greek           | Greek
+el-Latn     | Greek           | Latin
+en          | English         | Latin
+eo          | Esperanto       | Latin
+es          | Spanish         | Latin
+et          | Estonian        | Latin
+eu          | Basque          | Latin
+fa          | Persian         | Arabic
+fi          | Finnish         | Latin
+fil         | Filipino        | Latin
+fr          | French          | Latin
+fy          | Western Frisian | Latin
+ga          | Irish           | Latin
+gd          | Scottish Gaelic | Latin
+gl          | Galician        | Latin
+gu          | Gujarati        | Gujarati
+ha          | Hausa           | Latin
+haw         | Hawaiian        | Latin
+hi          | Hindi           | Devanagari
+hi-Latn     | Hindi           | Latin
+hmn         | Hmong           | Latin
+hr          | Croatian        | Latin
+ht          | Haitian Creole  | Latin
+hu          | Hungarian       | Latin
+hy          | Armenian        | Armenian
+id          | Indonesian      | Latin
+ig          | Igbo            | Latin
+is          | Icelandic       | Latin
+it          | Italian         | Latin
+iw          | Hebrew          | Hebrew
+ja          | Japanese        | Japanese
+ja-Latn     | Japanese        | Latin
+jv          | Javanese        | Latin
+ka          | Georgian        | Georgian
+kk          | Kazakh          | Cyrillic
+km          | Khmer           | Khmer
+kn          | Kannada         | Kannada
+ko          | Korean          | Korean
+ku          | Kurdish         | Latin
+ky          | Kyrgyz          | Cyrillic
+la          | Latin           | Latin
+lb          | Luxembourgish   | Latin
+lo          | Lao             | Lao
+lt          | Lithuanian      | Latin
+lv          | Latvian         | Latin
+mg          | Malagasy        | Latin
+mi          | Maori           | Latin
+mk          | Macedonian      | Cyrillic
+ml          | Malayalam       | Malayalam
+mn          | Mongolian       | Cyrillic
+mr          | Marathi         | Devanagari
+ms          | Malay           | Latin
+mt          | Maltese         | Latin
+my          | Burmese         | Myanmar
+ne          | Nepali          | Devanagari
+nl          | Dutch           | Latin
+no          | Norwegian       | Latin
+ny          | Nyanja          | Latin
+pa          | Punjabi         | Gurmukhi
+pl          | Polish          | Latin
+ps          | Pashto          | Arabic
+pt          | Portuguese      | Latin
+ro          | Romanian        | Latin
+ru          | Russian         | Cyrillic
+ru-Latn     | Russian         | English
+sd          | Sindhi          | Arabic
+si          | Sinhala         | Sinhala
+sk          | Slovak          | Latin
+sl          | Slovenian       | Latin
+sm          | Samoan          | Latin
+sn          | Shona           | Latin
+so          | Somali          | Latin
+sq          | Albanian        | Latin
+sr          | Serbian         | Cyrillic
+st          | Southern Sotho  | Latin
+su          | Sundanese       | Latin
+sv          | Swedish         | Latin
+sw          | Swahili         | Latin
+ta          | Tamil           | Tamil
+te          | Telugu          | Telugu
+tg          | Tajik           | Cyrillic
+th          | Thai            | Thai
+tr          | Turkish         | Latin
+uk          | Ukrainian       | Cyrillic
+ur          | Urdu            | Arabic
+uz          | Uzbek           | Latin
+vi          | Vietnamese      | Latin
+xh          | Xhosa           | Latin
+yi          | Yiddish         | Hebrew
+yo          | Yoruba          | Latin
+zh          | Chinese         | Han (including Simplified and Traditional)
+zh-Latn     | Chinese         | Latin
+zu          | Zulu            | Latin
 
 ### Installation
 CLD3 is designed to run in the Chrome browser, so it relies on code in


### PR DESCRIPTION
Update documentation to include list of supported languages. List sourced from kLanguageNames in src/task_context_params.cc
Language/script names taken directly from CLDR by matching codes, with the exception of Hebrew (iw/he mismatch).

Also fixed table of contents.