### PR TITLE
update cibuildwheel requirement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Install cibuildwheel
       run: |
-          python -m pip install cibuildwheel==1.5.5 auditwheel delocate
+          python -m pip install cibuildwheel>=1.5.5 auditwheel delocate
 
     - name: Build
       env:


### PR DESCRIPTION
It seems the old cibuildwheel was using centos 5.x through virtual machine to build the docker image. That OS went out of support and therefore there were no supported repositories to download the required packages.

I expected that the updated cibuildwheel would have solved that and sticking to a specific version was suboptimal decision.