### PR TITLE
Force -Wno-shadow to avoid variable shadowing warnings.

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -24,6 +24,10 @@ proto_library("protos") {
   proto_out_dir = "cld_3/protos"
 }
 
+config("warnings") {
+  cflags = [ "-Wno-shadow" ]
+}
+
 static_library("cld_3") {
   sources = [
     "base.cc",
@@ -90,6 +94,7 @@ static_library("cld_3") {
     "//third_party/protobuf:protobuf_lite",
     ":protos",
   ]
+  configs += [ ":warnings" ]
 }
 
 # The executables below are functional. Uncomment to use.


### PR DESCRIPTION
Long term, ideally, these would be fixed and this flag can be removed.
For now, this is an expedient way to allow enabling -Wshadow in
Chromium.

Bug: chromium:794619