### PR TITLE
Accept equal min_num_bytes and max_num_bytes

### DIFF
--- a/src/nnet_language_identifier.cc
+++ b/src/nnet_language_identifier.cc
@@ -123,7 +123,7 @@ NNetLanguageIdentifier::NNetLanguageIdentifier(int min_num_bytes,
       max_num_bytes_(max_num_bytes) {
   CLD3_CHECK(max_num_bytes_ > 0);
   CLD3_CHECK(min_num_bytes_ >= 0);
-  CLD3_CHECK(min_num_bytes_ < max_num_bytes_);
+  CLD3_CHECK(min_num_bytes_ <= max_num_bytes_);
 
   num_snippets_ = (max_num_bytes_ <= kNumSnippets) ? 1 : kNumSnippets;
   snippet_size_ = max_num_bytes_ / num_snippets_;


### PR DESCRIPTION
There is no reason to trap when `min_num_bytes` and `max_num_byte` equal.