### PR TITLE
Fix compilation with CMake and modern C++ compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.9)
 find_package(Protobuf REQUIRED)
 message(STATUS "Protobuf_FOUND= ${Protobuf_FOUND}")
 message(STATUS "Protobuf_VERSION= ${Protobuf_VERSION}")
-message(WARNING "Protobuf 3 and CLD3 seems happy together. This script does NOT check if your verison of protobuf is compatible.")
+message(WARNING "Protobuf 3 and CLD3 seems happy together. This script does NOT check if your version of protobuf is compatible.")
 message(STATUS "Protobuf_LIBRARIES= ${Protobuf_LIBRARIES}")
 message(STATUS "Protobuf_LITE_LIBRARIES= ${Protobuf_LITE_LIBRARIES}") # Usually /usr/lib64/libprotobuf-lite.so
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.9)
 find_package(Protobuf REQUIRED)
 message(STATUS "Protobuf_FOUND= ${Protobuf_FOUND}")
 message(STATUS "Protobuf_VERSION= ${Protobuf_VERSION}")
-message(WARNING "Protobuf 2.5 and CLD3 seems happy together. This script does NOT check if your verison of protobuf is compatible.")
+message(WARNING "Protobuf 3 and CLD3 seems happy together. This script does NOT check if your verison of protobuf is compatible.")
 message(STATUS "Protobuf_LIBRARIES= ${Protobuf_LIBRARIES}")
 message(STATUS "Protobuf_LITE_LIBRARIES= ${Protobuf_LITE_LIBRARIES}") # Usually /usr/lib64/libprotobuf-lite.so
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ my_protobuf_generate_cpp(cld_3/protos PROTO_SRCS PROTO_HDRS src/feature_extracto
 message(STATUS "PROTO_HDRS= ${PROTO_HDRS}")
 
 add_definitions(-fPIC) # Position Independant Code
-add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
+# add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
 add_definitions(-std=c++11) # Needed for std::to_string(), ...
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${Protobuf_INCLUDE_DIRS}) # needed to include generated pb headers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ my_protobuf_generate_cpp(cld_3/protos PROTO_SRCS PROTO_HDRS src/feature_extracto
 message(STATUS "PROTO_HDRS= ${PROTO_HDRS}")
 
 add_definitions(-fPIC) # Position Independant Code
-# add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
 add_definitions(-std=c++11) # Needed for std::to_string(), ...
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${Protobuf_INCLUDE_DIRS}) # needed to include generated pb headers


### PR DESCRIPTION
The usage of the [Dual ABI macro](https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html) was preventing the library to be used correctly with latest version of Protobuf library built with latest version of GCC.

Fix https://github.com/google/cld3/issues/84